### PR TITLE
Do not delete source maps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -86,6 +86,6 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     rm ${map}
 done
 
-rm "${files}"
+# rm "${files}"
 
 echo "       Done!"


### PR DESCRIPTION
We are protecting sourcemaps behind HTTP basic auth via nginx configuration. Hence we can safely host source maps.