### PR TITLE
Do not delete source maps

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -83,9 +83,9 @@ for map in $(find . -name '*.js.map' -not -path './node_modules/*' -not -path '.
     else
       echo "       ${map} is up-to-date (${name})"
     fi
-    rm ${map}
+    # rm ${map}
 done
 
-# rm "${files}"
+rm "${files}" # Deletes the temporary file created above
 
 echo "       Done!"


### PR DESCRIPTION
The previous PR had an issue. Instead of preventing deletion of map files, we were preventing deletion of the temporary file. This PR addresses the problem