### PR TITLE
Fix build fail on retry

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,7 @@
 set -e
 
 start=$(date +%s)
-echo "timestamp: $start"
+echo "(sentry) timestamp: $start"
 
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
@@ -23,7 +23,7 @@ if [[ ! -f "${JQ}" ]]; then
     curl -sSfL "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64" > "${JQ}"
     chmod +x "${JQ}"
     end=$(date +%s)
-    echo "time elapsed: $((end-start))s"
+    echo "(sentry) time elapsed: $((end-start))s"
 fi
 
 API="https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}"
@@ -39,7 +39,7 @@ curl -sSf "${API}/releases/" \
   >/dev/null
 
 end=$(date +%s)
-echo "time elapsed: $((end-start))s"
+echo "(sentry) time elapsed: $((end-start))s"
 
 # Retrieve files
 files=$(mktemp)
@@ -59,7 +59,7 @@ while [[ "${maps_res}" != "[]" ]]; do
 done
 
 end=$(date +%s)
-echo "time elapsed: $((end-start))s"
+echo "(sentry) time elapsed: $((end-start))s"
 
 if [[ $error == true ]]; then
     echo "Failed to get the existing sourcemaps"
@@ -68,7 +68,7 @@ elif [[ "${#mapslist[@]}" != "0" ]]; then
     echo "merging existing files response"
     $JQ -s [.[][]] "${mapslist[@]}" > "$files"
     end=$(date +%s)
-    echo "time elapsed: $((end-start))s"
+    echo "(sentry) time elapsed: $((end-start))s"
 fi
 
 # Upload the sourcemaps
@@ -121,5 +121,5 @@ rm "${files}" # Deletes the temporary file created above
 echo "       Done!"
 
 end=$(date +%s)
-echo "time elapsed: $((end-start))s"
-echo "timestamp: $end"
+echo "(sentry) time elapsed: $((end-start))s"
+echo "(sentry) timestamp: $end"

--- a/bin/compile
+++ b/bin/compile
@@ -36,10 +36,26 @@ curl -sSf "${API}/releases/" \
 # Retrieve files
 files=$(mktemp)
 echo "       Retrieving existing files to $files"
-curl -sSf "${API}/releases/${SOURCE_VERSION}/files/" \
-     -X GET \
-     -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}" \
-     > "$files"
+mapslist=()
+i=0
+while [[ "${maps_res}" != "[]" ]]; do
+    maps_res=$(curl -sSf "${API}/releases/${SOURCE_VERSION}/files/?cursor=100:${i}:0" -X GET -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}")
+    file=$(mktemp)
+    if [[ $(echo "${maps_res}" | $JQ type) != '"array"' ]]; then
+        error=true
+        break
+    fi
+    echo ${maps_res} > "$file"
+    mapslist[$i]=$file
+    ((i++))
+done
+
+if [[ $error == true ]]; then
+    echo "Failed to get the existing sourcemaps"
+    exit 1
+elif [[ "${#mapslist[@]}" != "0" ]]; then
+    $JQ -s [.[][]] "${mapslist[@]}" > "$files"
+fi
 
 # Upload the sourcemaps
 cd "${build}/"

--- a/bin/compile
+++ b/bin/compile
@@ -3,6 +3,9 @@
 
 set -e
 
+start=$(date +%s)
+echo "timestamp: $start"
+
 mkdir -p "$1" "$2"
 build=$(cd "$1/" && pwd)
 cache=$(cd "$2/" && pwd)
@@ -19,6 +22,8 @@ if [[ ! -f "${JQ}" ]]; then
     echo "-----> Downloading jq 1.5"
     curl -sSfL "https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64" > "${JQ}"
     chmod +x "${JQ}"
+    end=$(date +%s)
+    echo "time elapsed: $((end-start))s"
 fi
 
 API="https://sentry.io/api/0/projects/${SENTRY_ORG}/${SENTRY_PROJECT}"
@@ -32,6 +37,9 @@ curl -sSf "${API}/releases/" \
   -H 'Content-Type: application/json' \
   -d "{\"version\": \"${SOURCE_VERSION}\"}" \
   >/dev/null
+
+end=$(date +%s)
+echo "time elapsed: $((end-start))s"
 
 # Retrieve files
 files=$(mktemp)
@@ -50,11 +58,17 @@ while [[ "${maps_res}" != "[]" ]]; do
     ((i+=1))
 done
 
+end=$(date +%s)
+echo "time elapsed: $((end-start))s"
+
 if [[ $error == true ]]; then
     echo "Failed to get the existing sourcemaps"
     exit 1
 elif [[ "${#mapslist[@]}" != "0" ]]; then
+    echo "merging existing files response"
     $JQ -s [.[][]] "${mapslist[@]}" > "$files"
+    end=$(date +%s)
+    echo "time elapsed: $((end-start))s"
 fi
 
 # Upload the sourcemaps
@@ -105,3 +119,7 @@ done
 rm "${files}" # Deletes the temporary file created above
 
 echo "       Done!"
+
+end=$(date +%s)
+echo "time elapsed: $((end-start))s"
+echo "timestamp: $end"

--- a/bin/compile
+++ b/bin/compile
@@ -39,7 +39,6 @@ echo "       Retrieving existing files to $files"
 mapslist=()
 i=0
 while [[ "${maps_res}" != "[]" ]]; do
-    echo "fetching..."
     maps_res=$(curl -sSf "${API}/releases/${SOURCE_VERSION}/files/?cursor=100:${i}:0" -X GET -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}")
     file=$(mktemp)
     if [[ $(echo "${maps_res}" | $JQ type) != '"array"' ]]; then
@@ -48,11 +47,8 @@ while [[ "${maps_res}" != "[]" ]]; do
     fi
     echo ${maps_res} > "$file"
     mapslist[$i]=$file
-    ((i++))
+    ((i+=1))
 done
-
-echo "at least here"
-echo $JQ
 
 if [[ $error == true ]]; then
     echo "Failed to get the existing sourcemaps"

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,7 @@ echo "       Retrieving existing files to $files"
 mapslist=()
 i=0
 while [[ "${maps_res}" != "[]" ]]; do
+    echo "fetching..."
     maps_res=$(curl -sSf "${API}/releases/${SOURCE_VERSION}/files/?cursor=100:${i}:0" -X GET -H "Authorization: Bearer ${SENTRY_AUTH_TOKEN}")
     file=$(mktemp)
     if [[ $(echo "${maps_res}" | $JQ type) != '"array"' ]]; then
@@ -49,6 +50,9 @@ while [[ "${maps_res}" != "[]" ]]; do
     mapslist[$i]=$file
     ((i++))
 done
+
+echo "at least here"
+echo $JQ
 
 if [[ $error == true ]]; then
     echo "Failed to get the existing sourcemaps"


### PR DESCRIPTION
Fixes: https://github.com/Airbase/airbase-frontend/issues/3302

Heroku builds fail when this buildpack tries to upload the same sourcemaps to Sentry again. The buildpack does check whether the files are already present or not, however it does not follow the `next` link in the header response while checking for such files - this happens if the number of sourcemaps is greater than 100 (true for `airbase-frontend`). Consequently, it does not have the entire list of existing files on Sentry before trying the upload. This PR fixes that.

**Verification**:

See [this build](https://dashboard.heroku.com/apps/airbase-fron-circleci-s-co2lbm/activity/builds/934642cd-6951-40e5-be65-ceb3ff65b512) which has been created after the [previous successful build](https://dashboard.heroku.com/apps/airbase-fron-circleci-s-co2lbm/activity/builds/0dbab92c-d723-4f7f-8989-0f16375afc73).

**Testing**:

The `airbase-fron-circleci-s-co2lbm` review app has the appropriate Sentry env vars set.

1. Go to [the deploy page](https://dashboard.heroku.com/apps/airbase-fron-circleci-s-co2lbm/deploy/github) and trigger a `Manual Deploy`.
2. After the build succeeds, verify from the build logs that it uploads all the sourcemaps to Sentry.
3. Trigger the build manually again.
4. After the build succeeds, verify from the build logs that almost all sourcemaps are `up-to-date` and only a few are uploaded/updated (if at all).
5. **Note that doing the above steps creates a new release on Sentry. Delete that release manually  from the releases page.**